### PR TITLE
Typo Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ tns plugin add nativescript-accelerometer
 
 ## Usage
 ```
-var accelerometer = require("native-script-accelerometer");
+var accelerometer = require("nativescript-accelerometer");
 
-accelerometer.startAccelometerUpdates(function(data) {
+accelerometer.startAccelerometerUpdates(function(data) {
     console.log("x: " + data.x + "y: " + data.y + "z: " + data.z);
 });
 ```

--- a/index.android.js
+++ b/index.android.js
@@ -3,10 +3,10 @@ var application = require('application');
 var baseAcceleration = 9.81;
 var sensorListener;
 var sensorManager;
-var accelometerSensor;
-function startAccelometerUpdates(callback) {
+var accelerometerSensor;
+function startAccelerometerUpdates(callback) {
     if (sensorListener) {
-        throw new Error("Already listetning for accelometer updates.");
+        throw new Error("Already listening for accelerometer updates.");
     }
     var activity = application.android.foregroundActivity;
     if (!activity) {
@@ -18,10 +18,10 @@ function startAccelometerUpdates(callback) {
             throw Error("Could not initalize SensorManager.");
         }
     }
-    if (!accelometerSensor) {
-        accelometerSensor = sensorManager.getDefaultSensor(android.hardware.Sensor.TYPE_ACCELEROMETER);
-        if (!accelometerSensor) {
-            throw Error("Could get accelometer sensor.");
+    if (!accelerometerSensor) {
+        accelerometerSensor = sensorManager.getDefaultSensor(android.hardware.Sensor.TYPE_ACCELEROMETER);
+        if (!accelerometerSensor) {
+            throw Error("Could get accelerometer sensor.");
         }
     }
     sensorListener = new android.hardware.SensorEventListener({
@@ -35,14 +35,14 @@ function startAccelometerUpdates(callback) {
             });
         }
     });
-    sensorManager.registerListener(sensorListener, accelometerSensor, android.hardware.SensorManager.SENSOR_DELAY_NORMAL);
+    sensorManager.registerListener(sensorListener, accelerometerSensor, android.hardware.SensorManager.SENSOR_DELAY_NORMAL);
 }
-exports.startAccelometerUpdates = startAccelometerUpdates;
-function stopAccelometerUpdates() {
+exports.startAccelerometerUpdates = startAccelometerUpdates;
+function stopAccelerometerUpdates() {
     if (!sensorListener) {
         throw new Error("Currently not listening for acceleration events.");
     }
     sensorManager.unregisterListener(sensorListener);
     sensorListener = undefined;
 }
-exports.stopAccelometerUpdates = stopAccelometerUpdates;
+exports.stopAccelerometerUpdates = stopAccelerometerUpdates;

--- a/index.android.js
+++ b/index.android.js
@@ -37,7 +37,7 @@ function startAccelerometerUpdates(callback) {
     });
     sensorManager.registerListener(sensorListener, accelerometerSensor, android.hardware.SensorManager.SENSOR_DELAY_NORMAL);
 }
-exports.startAccelerometerUpdates = startAccelometerUpdates;
+exports.startAccelerometerUpdates = startAccelerometerUpdates;
 function stopAccelerometerUpdates() {
     if (!sensorListener) {
         throw new Error("Currently not listening for acceleration events.");

--- a/index.android.ts
+++ b/index.android.ts
@@ -1,14 +1,14 @@
 import application = require('application');
 declare var android: any;
-interface AccelomenterData { x: number; y: number; z: number };
+interface AccelerometerData { x: number; y: number; z: number };
 
 const baseAcceleration = 9.81;
 var sensorListener;
 var sensorManager;
-var accelometerSensor
-export function startAccelometerUpdates(callback: (AccelomenterData) => void) {
+var accelerometerSensor;
+export function startAccelerometerUpdates(callback: (AccelerometerData) => void) {
     if (sensorListener) {
-        throw new Error("Already listetning for accelometer updates.")
+        throw new Error("Already listening for accelerometer updates.")
     }
 
     var activity = application.android.foregroundActivity;
@@ -26,10 +26,10 @@ export function startAccelometerUpdates(callback: (AccelomenterData) => void) {
         }
     }
 
-    if (!accelometerSensor) {
-        accelometerSensor = sensorManager.getDefaultSensor(android.hardware.Sensor.TYPE_ACCELEROMETER);
-        if (!accelometerSensor) {
-            throw Error("Could get accelometer sensor.")
+    if (!accelerometerSensor) {
+        accelerometerSensor = sensorManager.getDefaultSensor(android.hardware.Sensor.TYPE_ACCELEROMETER);
+        if (!accelerometerSensor) {
+            throw Error("Could get accelerometer sensor.")
         }
     }
 
@@ -48,12 +48,12 @@ export function startAccelometerUpdates(callback: (AccelomenterData) => void) {
 
     sensorManager.registerListener(
         sensorListener,
-        accelometerSensor,
+        accelerometerSensor,
         android.hardware.SensorManager.SENSOR_DELAY_NORMAL
     );
 }
 
-export function stopAccelometerUpdates() {
+export function stopAccelerometerUpdates() {
     if (!sensorListener) {
         throw new Error("Currently not listening for acceleration events.")
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
-export interface AccelomenterData {
+export interface AccelerometerData {
     x: number;
     y: number;
     z: number;
 }
 
-export function startAccelometerUpdates(callback: (AccelomenterData) => void);
-export function stopAccelometerUpdates();
+export function startAccelerometerUpdates(callback: (AccelerometerData) => void);
+export function stopAccelerometerUpdates();

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,9 @@
 ;
 var accMnager;
 var isListeneing = false;
-function startAccelometerUpdates(callback) {
+function startAccelerometerUpdates(callback) {
     if (isListeneing) {
-        throw new Error("Already listetning for accelometer updates.");
+        throw new Error("Already listening for accelerometer updates.");
     }
     if (!accMnager) {
         accMnager = CMMotionManager.alloc().init();
@@ -24,12 +24,12 @@ function startAccelometerUpdates(callback) {
         throw new Error("Accelerometer not available.");
     }
 }
-exports.startAccelometerUpdates = startAccelometerUpdates;
-function stopAccelometerUpdates() {
+exports.startAccelerometerUpdates = startAccelerometerUpdates;
+function stopAccelerometerUpdates() {
     if (!isListeneing) {
         throw new Error("Currently not listening for acceleration events.");
     }
     accMnager.stopAccelerometerUpdates();
     isListeneing = false;
 }
-exports.stopAccelometerUpdates = stopAccelometerUpdates;
+exports.stopAccelerometerUpdates = stopAccelerometerUpdates;

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,8 +1,8 @@
 ;
 var accMnager;
-var isListeneing = false;
+var isListening = false;
 function startAccelerometerUpdates(callback) {
-    if (isListeneing) {
+    if (isListening) {
         throw new Error("Already listening for accelerometer updates.");
     }
     if (!accMnager) {
@@ -18,7 +18,7 @@ function startAccelerometerUpdates(callback) {
                 z: data.acceleration.z
             });
         });
-        isListeneing = true;
+        isListening = true;
     }
     else {
         throw new Error("Accelerometer not available.");
@@ -26,10 +26,10 @@ function startAccelerometerUpdates(callback) {
 }
 exports.startAccelerometerUpdates = startAccelerometerUpdates;
 function stopAccelerometerUpdates() {
-    if (!isListeneing) {
+    if (!isListening) {
         throw new Error("Currently not listening for acceleration events.");
     }
     accMnager.stopAccelerometerUpdates();
-    isListeneing = false;
+    isListening = false;
 }
 exports.stopAccelerometerUpdates = stopAccelerometerUpdates;

--- a/index.ios.ts
+++ b/index.ios.ts
@@ -7,7 +7,7 @@ var accMnager;
 var isListening = false;
 
 export function startAccelerometerUpdates(callback: (AccelerometerData) => void) {
-    if (isListeneing) {
+    if (isListening) {
         throw new Error("Already listening for accelerometer updates.")
     }
 
@@ -26,17 +26,17 @@ export function startAccelerometerUpdates(callback: (AccelerometerData) => void)
             })
         });
 
-        isListeneing = true;
+        isListening = true;
     } else {
         throw new Error("Accelerometer not available.")
     }
 }
 
 export function stopAccelerometerUpdates() {
-    if (!isListeneing) {
+    if (!isListening) {
         throw new Error("Currently not listening for acceleration events.")
     }
 
     accMnager.stopAccelerometerUpdates();
-    isListeneing = false;
+    isListening = false;
 }

--- a/index.ios.ts
+++ b/index.ios.ts
@@ -6,7 +6,7 @@ interface AccelerometerData { x: number; y: number; z: number };
 var accMnager;
 var isListening = false;
 
-export function startAccelerometerUpdates(callback: (AccelomenterData) => void) {
+export function startAccelerometerUpdates(callback: (AccelerometerData) => void) {
     if (isListeneing) {
         throw new Error("Already listening for accelerometer updates.")
     }

--- a/index.ios.ts
+++ b/index.ios.ts
@@ -1,14 +1,14 @@
 declare var CMMotionManager: any;
 declare var NSOperationQueue: any;
 
-interface AccelomenterData { x: number; y: number; z: number };
+interface AccelerometerData { x: number; y: number; z: number };
 
 var accMnager;
-var isListeneing = false;
+var isListening = false;
 
-export function startAccelometerUpdates(callback: (AccelomenterData) => void) {
+export function startAccelerometerUpdates(callback: (AccelomenterData) => void) {
     if (isListeneing) {
-        throw new Error("Already listetning for accelometer updates.")
+        throw new Error("Already listening for accelerometer updates.")
     }
 
     if (!accMnager) {
@@ -32,7 +32,7 @@ export function startAccelometerUpdates(callback: (AccelomenterData) => void) {
     }
 }
 
-export function stopAccelometerUpdates() {
+export function stopAccelerometerUpdates() {
     if (!isListeneing) {
         throw new Error("Currently not listening for acceleration events.")
     }


### PR DESCRIPTION
If it was intentional, no problem to disregard but figured it would clean it up some to have correct spelling on the functions and variables. 

Especially for those who might spell out the `startAccelerometerUpdates` as opposed to copying/pasting from the README. It caught me by surprise when it crashed and had me looking at the source.
